### PR TITLE
bump sbt-dotenv

### DIFF
--- a/00-Starter-Seed/regular-webapp/project/plugins.sbt
+++ b/00-Starter-Seed/regular-webapp/project/plugins.sbt
@@ -19,4 +19,4 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-mocha" % "1.0.0")
 
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.5.0")
 
-addSbtPlugin("au.com.onegeek" %% "sbt-dotenv" % "1.2.58")
+addSbtPlugin("au.com.onegeek" %% "sbt-dotenv" % "2.0.106")


### PR DESCRIPTION
## Reason of this PR
Before [this change](https://github.com/mefellows/sbt-dotenv/pull/25/files#diff-d8eae58ef13bb302373e84ebc25ed8efR78) in sbt-dotenv, a quated value was substituted while remaining to be quated.

Because of this reason, the setting in README.md
`AUTH0_CALLBACK_URL="http://localhost:9000/callback"`

resulted URL like here when I hit the button `SIGN IN`
`https://myauth0domain/authorize?client_id=myclientid&redirect_uri=%22http://localhost:9000/callback%22&response_type=code&scope=openid%20profile&audience=https://myauth0domain/userinfo&state=s00ea80j8rv94q98bmsof9ko`